### PR TITLE
Minor FFI performance tweaks

### DIFF
--- a/src/DOM/WebStorage/Storage.js
+++ b/src/DOM/WebStorage/Storage.js
@@ -27,7 +27,7 @@ exports.newMockStorage = function() {
       delete storage[key];
     },
     clear: function() {
-      Object.keys(storage).forEach(this.removeItem, this);
+      storage = {};
     }
   };
 };

--- a/src/DOM/WebStorage/String.js
+++ b/src/DOM/WebStorage/String.js
@@ -16,15 +16,12 @@ exports.getItemImpl = function(nothing, just, storage, key) {
 
 exports.setItemImpl = function(storage, key, item) {
   storage.setItem(key, item);
-  return {};
 };
 
 exports.removeItemImpl = function(storage, key) {
   storage.removeItem(key);
-  return {};
 };
 
 exports.clearImpl = function(storage) {
   storage.clear();
-  return {};
 };


### PR DESCRIPTION
The storage mock never exposes the internal `storage` object, so replacing it is just as effective and safe as clearing it one key at a time.  Also removed some object allocation for functions typed with `Unit`, as the value is never used.
